### PR TITLE
Add section for apps that are PSP Certified

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ To apply for certification, open a new [issue](https://github.com/Podcast-Standa
 * Product/service category (hosting, player app, validation, etc.)
 * A short description of your service (one sentence)
 * Your contact information (email, twitter)
+
+## Who is PSP Certified?
+
+Currently the following podcast players and hosting providers have met the standard for PSP Certification.
+
+### Podcast listening apps
+
+* [Steno.fm](https://www.steno.fm/)
+* [Podverse](https://podverse.fm/)
+* [Podfriend](https://www.podfriend.com/)
+* [Curiocaster](https://curiocaster.com/)
+
+### Podcast hosting providers
+
+* [blubrry](https://blubrry.com/)
+* [Buzzsprout](https://www.buzzsprout.com/)
+* [Captivate](https://www.captivate.fm/)
+* [Redcircle](https://redcircle.com/)
+* [RSS.com](https://rss.com/)
+* [Transistor](https://transistor.fm/)


### PR DESCRIPTION
The more visibility we can provide for hosting providers and listening apps that are PSP Certified, the more momentum we'll have in terms of other apps wanting to become certified.

@TheCraigHewitt: any chance we can get Castos on this list soon? 🙏 